### PR TITLE
Write to file in binary mode

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -68,7 +68,7 @@ def parse_and_save_message(message):
     else:
         path = os.path.join(output, path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path,'w') as f:
+        with open(path,'wb') as f:
             f.write(email.as_bytes())
     return True
 


### PR DESCRIPTION
Since we're writing bytes, write in binary mode.
Fixes error: 
```
Traceback (most recent call last):
  File "backup.py", line 103, in <module>
    if parse_and_save_message(message) and args.delete:
  File "backup.py", line 72, in parse_and_save_message
    f.write(email.as_bytes())
TypeError: write() argument must be str, not bytes
```